### PR TITLE
Update video.py

### DIFF
--- a/gaupol/agents/video.py
+++ b/gaupol/agents/video.py
@@ -332,13 +332,16 @@ class VideoAgent(aeidon.Delegate):
         menu = self.get_menubar_section("audio-languages-placeholder")
         menu.remove_all()
         languages = self.player.get_audio_languages()
-        for i, language in enumerate(languages):
-            language = language or _("Undefined")
-            action = "win.set-audio-language::{:d}".format(i)
-            menu.append(language, action)
-            if i == self.player.audio_track:
-                action = self.get_action("set-audio-language")
-                action.set_state(str(i))
+        if languages is None:
+            pass
+        else:
+            for i, language in enumerate(languages):
+                language = language or _("Undefined")
+                action = "win.set-audio-language::{:d}".format(i)
+                menu.append(language, action)
+                if i == self.player.audio_track:
+                    action = self.get_action("set-audio-language")
+                    action.set_state(str(i))
 
     def _update_subtitle_cache(self, *args, **kwargs):
         """Update subtitle position and text cache."""


### PR DESCRIPTION
The method `player.get_audio_languages` can return `None`, but that case wasn't being dealt with. I got the error while trying to load a video in my `Archlinux` system using `gaupol-0.92-1`, and it was getting in the way so I couldn't load any video. You may want to deal with this in a fancier manner but for the time being this is an easy fix that worked for me.

Actually let me say that this isn't a fix, but it opened up the way for the true error message to appear, instead of the `python Nonetype traceback` error that wasn't really saying much. That then allowed me to figure out that the problem was the `gstreamer` component missing some codecs with an error along the lines of: `gst stream error quark your gstreamer installation is missing a plug-in`. In my case installing `gst-libav` from the repositories solved the issue. Now it loads the video with or without this fix so it's not a fix but a path opener for the true error to go through. Perhaps you may want to add some message instead. I was going to close the pull request but I'll leave it open for historical purposes I guess.