### PR TITLE
Fix duplicate tags when decoding MPL2

### DIFF
--- a/aeidon/markups/mpl2.py
+++ b/aeidon/markups/mpl2.py
@@ -19,6 +19,8 @@
 
 import aeidon
 
+from collections import OrderedDict
+
 __all__ = ("MPL2",)
 
 
@@ -78,7 +80,7 @@ class MPL2(aeidon.markups.MicroDVD):
             match = re_tag.search(line)
             if match is None: continue
             lines[i] = match.group(2)
-            for tag in reversed(sorted(set(match.group(1)))):
+            for tag in reversed(OrderedDict.fromkeys(match.group(1))):
                 lines[i] = "<{}>{}</{}>".format(tag, lines[i], tag)
         return "\n".join(lines)
 

--- a/aeidon/markups/mpl2.py
+++ b/aeidon/markups/mpl2.py
@@ -74,6 +74,8 @@ class MPL2(aeidon.markups.MicroDVD):
         """
         lines = text.split("\n")
         for i, line in enumerate(lines):
+            if not line:
+                continue
             tags = []
             while line[0] in '\\/_' and line[0] not in tags:
                 tags.append(line[0])

--- a/aeidon/markups/mpl2.py
+++ b/aeidon/markups/mpl2.py
@@ -73,16 +73,13 @@ class MPL2(aeidon.markups.MicroDVD):
         tags ``</\\>``, ``<//>`` and ``</_>``.
         """
         lines = text.split("\n")
+        re_tag = self._get_regex(r"^([\\/_]+)(.*)$")
         for i, line in enumerate(lines):
-            if not line:
-                continue
-            tags = []
-            while line[0] in '\\/_' and line[0] not in tags:
-                tags.append(line[0])
-                line = line[1:]
-            for tag in reversed(tags):
-                line = "<{}>{}</{}>".format(tag, line, tag)
-            lines[i] = line
+            match = re_tag.search(line)
+            if match is None: continue
+            lines[i] = match.group(2)
+            for tag in reversed(match.group(1)):
+                lines[i] = "<{}>{}</{}>".format(tag, lines[i], tag)
         return "\n".join(lines)
 
     def _style_mpl2(self, text, tag, bounds=None):

--- a/aeidon/markups/mpl2.py
+++ b/aeidon/markups/mpl2.py
@@ -78,7 +78,7 @@ class MPL2(aeidon.markups.MicroDVD):
             match = re_tag.search(line)
             if match is None: continue
             lines[i] = match.group(2)
-            for tag in reversed(match.group(1)):
+            for tag in reversed(sorted(set(match.group(1)))):
                 lines[i] = "<{}>{}</{}>".format(tag, lines[i], tag)
         return "\n".join(lines)
 

--- a/aeidon/markups/mpl2.py
+++ b/aeidon/markups/mpl2.py
@@ -73,13 +73,14 @@ class MPL2(aeidon.markups.MicroDVD):
         tags ``</\\>``, ``<//>`` and ``</_>``.
         """
         lines = text.split("\n")
-        re_tag = self._get_regex(r"^([\\/_]+)(.*)$")
         for i, line in enumerate(lines):
-            match = re_tag.search(line)
-            if match is None: continue
-            lines[i] = match.group(2)
-            for tag in reversed(match.group(1)):
-                lines[i] = "<{}>{}</{}>".format(tag, lines[i], tag)
+            tags = []
+            while line[0] in '\\/_' and line[0] not in tags:
+                tags.append(line[0])
+                line = line[1:]
+            for tag in reversed(tags):
+                line = "<{}>{}</{}>".format(tag, line, tag)
+            lines[i] = line
         return "\n".join(lines)
 
     def _style_mpl2(self, text, tag, bounds=None):

--- a/aeidon/markups/test/test_mpl2.py
+++ b/aeidon/markups/test/test_mpl2.py
@@ -58,8 +58,8 @@ class TestMPL2(TestMicroDVD):
         text = ("//All things weird are normal\n"
                 "/_/_in this whore of cities.")
         assert self.markup.decode(text) == (
-            "<i>/All things weird are normal</i>\n"
-            "<i><u>/_in this whore of cities.</u></i>")
+            "<i>All things weird are normal</i>\n"
+            "<i><u>in this whore of cities.</u></i>")
 
     def test_decode__underline(self):
         text = ("All things weird are normal\n"

--- a/aeidon/markups/test/test_mpl2.py
+++ b/aeidon/markups/test/test_mpl2.py
@@ -54,6 +54,13 @@ class TestMPL2(TestMicroDVD):
             "<i><u>All things weird are normal</u></i>\n"
             "<b><i><u>in this whore of cities.</u></i></b>")
 
+    def test_decode__duplicate(self):
+        text = ("//All things weird are normal\n"
+                "/_/_in this whore of cities.")
+        assert self.markup.decode(text) == (
+            "<i>/All things weird are normal</i>\n"
+            "<i><u>/_in this whore of cities.</u></i>")
+
     def test_decode__underline(self):
         text = ("All things weird are normal\n"
                 "_in this whore of cities.")


### PR DESCRIPTION
MPL2:
```
//All things weird are normal
/_/_in this whore of cities.
```

Internal markup (before):
```
<i><i>All things weird are normal</i></i>
<i><u><i><u>in this whore of cities.</u></i></u></i>
```

Internal markup (after):
```
<i>/All things weird are normal</i>
<i><u>/_in this whore of cities.</u></i>
```