### PR TITLE
Fix the order of audio tracks in the menu

### DIFF
--- a/gaupol/__init__.py
+++ b/gaupol/__init__.py
@@ -44,6 +44,7 @@ for module, version in {
     "Gst": "1.0",
     "GstPbutils": "1.0",
     "GstVideo": "1.0",
+    "GstTag": "1.0",
 }.items():
     with aeidon.util.silent(Exception):
         gi.require_version(module, version)

--- a/gaupol/agents/video.py
+++ b/gaupol/agents/video.py
@@ -27,7 +27,11 @@ from gi.repository import GLib
 from gi.repository import Gtk
 
 with aeidon.util.silent(Exception):
+    from gi import require_version
+    require_version('GstTag', '1.0')
     from gi.repository import Gst
+    from gi.repository import GstTag
+
 
 
 class VideoAgent(aeidon.Delegate):
@@ -348,11 +352,17 @@ class VideoAgent(aeidon.Delegate):
         """Update the audio language selection menu."""
         menu = self.get_menubar_section("audio-languages-placeholder")
         menu.remove_all()
-        languages = self.player.get_audio_languages()
-        for i, language in enumerate(languages):
-            language = language or _("Undefined")
+        tracks = self.player.get_audio_infos()
+        for i, track in enumerate(tracks):
+            title = track.title or "{} {}".format(_("Track"), i + 1)
+            lang = None
+            if track.language_code is not None:
+                lang = GstTag.tag_get_language_name(track.language_code)
+            if lang is None:
+                lang = track.language_name
+            name = title if lang is None else "{} - [{}]".format(title, lang.title())
             action = "win.set-audio-language::{:d}".format(i)
-            menu.append(language, action)
+            menu.append(name, action)
             if i == self.player.audio_track:
                 action = self.get_action("set-audio-language")
                 action.set_state(str(i))

--- a/gaupol/agents/video.py
+++ b/gaupol/agents/video.py
@@ -27,8 +27,6 @@ from gi.repository import GLib
 from gi.repository import Gtk
 
 with aeidon.util.silent(Exception):
-    from gi import require_version
-    require_version('GstTag', '1.0')
     from gi.repository import Gst
     from gi.repository import GstTag
 
@@ -354,7 +352,7 @@ class VideoAgent(aeidon.Delegate):
         menu.remove_all()
         tracks = self.player.get_audio_infos()
         for i, track in enumerate(tracks):
-            title = track.title or "{} {}".format(_("Track"), i + 1)
+            title = track.title or _("Track {:d}").format(i + 1)
             lang = None
             if track.language_code is not None:
                 lang = GstTag.tag_get_language_name(track.language_code)

--- a/gaupol/player.py
+++ b/gaupol/player.py
@@ -118,7 +118,8 @@ class VideoPlayer(aeidon.Observable):
 
     def get_audio_languages(self):
         """Return a sequence of audio languages or ``None``."""
-        return tuple(x.get_language() for x in self._info.get_audio_streams())
+        return tuple(self._playbin.emit("get-audio-tags", i).get_string("language-code")[1]
+                     for i in range(self._playbin.props.n_audio))
 
     def get_duration(self, mode=None):
         """Return duration of video stream or ``None``."""
@@ -356,6 +357,10 @@ class VideoPlayer(aeidon.Observable):
             dialog.add_button(_("_OK"), Gtk.ResponseType.OK)
             dialog.set_default_response(Gtk.ResponseType.OK)
             gaupol.util.flash_dialog(dialog)
+        else:
+            # Make stream tags available from _playbin
+            self._playbin.set_state(Gst.State.PAUSED)
+            self._playbin.get_state(Gst.CLOCK_TIME_NONE)
 
     def stop(self):
         """Stop."""

--- a/gaupol/player.py
+++ b/gaupol/player.py
@@ -21,6 +21,7 @@ import aeidon
 import gaupol
 import time
 
+from collections import namedtuple
 from aeidon.i18n   import _
 from gi.repository import GLib
 from gi.repository import Gtk
@@ -55,6 +56,8 @@ class VideoPlayer(aeidon.Observable):
     """
 
     signals = ("state-changed",)
+
+    TrackInfo = namedtuple("TrackInfo", ["title", "language_code", "language_name"])
 
     def __init__(self):
         """Initialize a :class:`VideoPlayer` instance."""
@@ -116,10 +119,19 @@ class VideoPlayer(aeidon.Observable):
         self._playbin.seek_simple(Gst.Format.TIME, seek_flags, pos)
         self._in_default_segment = True
 
-    def get_audio_languages(self):
-        """Return a sequence of audio languages or ``None``."""
-        return tuple(self._playbin.emit("get-audio-tags", i).get_string("language-code")[1]
-                     for i in range(self._playbin.props.n_audio))
+    def get_audio_infos(self):
+        """Return a sequence of audio track infos."""
+        return tuple(
+            self._make_track_infos(self._playbin.emit("get-audio-tags", i))
+            for i in range(self._playbin.props.n_audio)
+        )
+
+    def _make_track_infos(self, tags):
+        return self.TrackInfo(
+            tags.get_string("title")[1],
+            tags.get_string("language-code")[1],
+            tags.get_string("language-name")[1]
+        )
 
     def get_duration(self, mode=None):
         """Return duration of video stream or ``None``."""


### PR DESCRIPTION
Fix #129 by using track infos from `Playbin` rather than from `Discoverer`.
By the way, implement VLC-like track names in the menu.