### PR TITLE
Make svg2ico script compatible with modern Inkscape and insensitive to working directory

### DIFF
--- a/data/icons/svg2ico
+++ b/data/icons/svg2ico
@@ -1,4 +1,5 @@
 #!/bin/sh
+cd "$(dirname "$0")" || exit 1
 # https://docs.microsoft.com/en-us/windows/win32/uxguide/vis-icons#size-requirements
 for SIZE in 256 48 32 16; do inkscape -o $SIZE.png -C -w $SIZE io.otsaloma.gaupol.svg; done
 convert 256.png 48.png 32.png 16.png -background transparent io.otsaloma.gaupol.ico

--- a/data/icons/svg2ico
+++ b/data/icons/svg2ico
@@ -1,5 +1,5 @@
 #!/bin/sh
 # https://docs.microsoft.com/en-us/windows/win32/uxguide/vis-icons#size-requirements
-for SIZE in 256 48 32 16; do inkscape -e $SIZE.png -C -w $SIZE io.otsaloma.gaupol.svg; done
+for SIZE in 256 48 32 16; do inkscape -o $SIZE.png -C -w $SIZE io.otsaloma.gaupol.svg; done
 convert 256.png 48.png 32.png 16.png -background transparent io.otsaloma.gaupol.ico
 rm -f 256.png 48.png 32.png 16.png


### PR DESCRIPTION
In `svg2ico`, keep using `--export-png` (equivalent to `-e`) for old Inkscape versions that support only it; use `--export-filename` (equivalent to `-o`) for newer Inkscape versions (at least 1.x) that support only it.

Additionally, have `svg2ico` always operate in the directory containing the script, so it does not have to be run from that directory.