### PR TITLE
Use importlib.reload instead of imp.reload (Python 3.12 compat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ and gettext to build the Flatpak.
 
 #### Source
 
-Gaupol requires Python ≥ 3.2, PyGObject ≥ 3.12 and GTK ≥ 3.12.
+Gaupol requires Python ≥ 3.4, PyGObject ≥ 3.12 and GTK ≥ 3.12.
 Additionally, during installation you need gettext. Optional, but
 strongly recommended dependencies include:
 

--- a/aeidon/test/test_locales.py
+++ b/aeidon/test/test_locales.py
@@ -16,10 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import aeidon
-try:
-    from importlib import reload  # Python 3.4 and later
-except ImportError:
-    from imp import reload  # Python 3.11 and older
+import importlib
 
 from aeidon.i18n   import _, d_
 from unittest.mock import patch
@@ -49,10 +46,10 @@ class TestModule(aeidon.TestCase):
 
     @patch.dict("os.environ", dict(LANGUAGE="sr@Latn"))
     def test_get_system_modifier__latn(self):
-        reload(aeidon.locales)
+        importlib.reload(aeidon.locales)
         assert aeidon.locales.get_system_modifier() == "Latn"
 
     @patch.dict("os.environ", dict(LANGUAGE="en"))
     def test_get_system_modifier__none(self):
-        reload(aeidon.locales)
+        importlib.reload(aeidon.locales)
         assert aeidon.locales.get_system_modifier() is None

--- a/aeidon/test/test_locales.py
+++ b/aeidon/test/test_locales.py
@@ -16,7 +16,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import aeidon
-import imp
+try:
+    from importlib import reload  # Python 3.4 and later
+except ImportError:
+    from imp import reload  # Python 3.11 and older
 
 from aeidon.i18n   import _, d_
 from unittest.mock import patch
@@ -46,10 +49,10 @@ class TestModule(aeidon.TestCase):
 
     @patch.dict("os.environ", dict(LANGUAGE="sr@Latn"))
     def test_get_system_modifier__latn(self):
-        imp.reload(aeidon.locales)
+        reload(aeidon.locales)
         assert aeidon.locales.get_system_modifier() == "Latn"
 
     @patch.dict("os.environ", dict(LANGUAGE="en"))
     def test_get_system_modifier__none(self):
-        imp.reload(aeidon.locales)
+        reload(aeidon.locales)
         assert aeidon.locales.get_system_modifier() is None


### PR DESCRIPTION
In `aeidon/test/test_locales.py`, use `importlib.reload` where available (Python 3.4 and later) instead of `imp.reload`; the `imp` module [has been deprecated since Python 3.4 and is removed in Python 3.12](https://docs.python.org/3/library/imp.html), so this is a Python 3.12 compatibility fix.

The fallback to `imp.reload` is preserved since `README.md` claims support for Python 3.2.