### PR TITLE
Fix deprecated top-level developer_name in AppData XML

### DIFF
--- a/data/io.otsaloma.gaupol.appdata.xml.in
+++ b/data/io.otsaloma.gaupol.appdata.xml.in
@@ -36,7 +36,9 @@
     <mediatype>text/x-subviewer</mediatype>
   </provides>
   <project_license>GPL-3.0+</project_license>
-  <developer_name>Osmo Salomaa</developer_name>
+  <developer>
+    <name>Osmo Salomaa</name>
+  </developer>
   <screenshots>
     <screenshot type="default">
       <image>https://otsaloma.io/gaupol/screenshot-appdata.png</image>


### PR DESCRIPTION
Use the `name` element in a `developer` block instead, as recommended by `appstreamcli` 1.0.0.

This fixes all warnings when validating the AppData XML file, although there are still informational messages:

```
I: io.otsaloma.gaupol.desktop:67: developer-id-missing
   The `developer` element is missing an `id` property, containing a unique string ID for the
   developer. Consider adding a unique ID.
  
✔ Validation was successful: infos: 1
```