### PR TITLE
Fix wrong release version in AppStream XML

### DIFF
--- a/data/io.otsaloma.gaupol.appdata.xml.in
+++ b/data/io.otsaloma.gaupol.appdata.xml.in
@@ -21,7 +21,7 @@
   <url type="translate">https://www.transifex.com/otsaloma/gaupol/</url>
   <launchable type="desktop-id">io.otsaloma.gaupol.desktop</launchable>
   <releases>
-    <release version="1.13"   date="2024-03-31"/>
+    <release version="1.14"   date="2024-03-31"/>
     <release version="1.13"   date="2023-10-08"/>
     <release version="1.12"   date="2023-01-21"/>
     <release version="1.11"   date="2022-04-03"/>


### PR DESCRIPTION
This fixes validation errors:

```
$ appstream-util validate-relax --nonet /[...]/io.otsaloma.gaupol.appdata.xml
/[...]/io.otsaloma.gaupol.appdata.xml: FAILED:
• tag-invalid           : <release> version was duplicated
Validation of files failed
```

(Validation with `appstreamcli validate` 1.0.2 doesn’t complain about this.)