### PR TITLE
Fix the gaupol binary run when using separate python-aeidon package

### DIFF
--- a/setup-aeidon.py
+++ b/setup-aeidon.py
@@ -11,6 +11,7 @@ from setuptools import setup
 # Copy data files to the aeidon package, so they can be included.
 shutil.copytree("data/headers", "aeidon/data/headers")
 shutil.copytree("data/patterns", "aeidon/data/patterns")
+shutil.copytree("data/ui", "aeidon/data/ui")
 
 with open("README.aeidon.md", "r") as f:
     long_description = f.read()


### PR DESCRIPTION
Recently in Fedora Linux we separated python-aeidon library package from gaupol package. After that some user reported that gaupol binary run is failing for requiring some ui files. With this fix gaupol binary run is not crashing anymore.

Request to consider this fix by merging in upstream tarball of aeidon library.

The downstream bug is https://bugzilla.redhat.com/show_bug.cgi?id=2395486