### PR TITLE
Do not crash reading SubRip with text before the first time line

### DIFF
--- a/aeidon/files/subrip.py
+++ b/aeidon/files/subrip.py
@@ -47,6 +47,10 @@ class SubRip(aeidon.SubtitleFile):
         for line in self._read_lines():
             match = self._re_time_line.match(line)
             if match is None:
+                if not subtitles:
+                    # Text before the first time line does not belong to any
+                    # subtitle; skip it rather than raising an IndexError.
+                    continue
                 if subtitles[-1].main_text:
                     subtitles[-1].main_text += "\n"
                 subtitles[-1].main_text += line

--- a/aeidon/files/test/test_subrip.py
+++ b/aeidon/files/test/test_subrip.py
@@ -29,6 +29,19 @@ class TestSubRip(aeidon.TestCase):
     def test_read(self):
         assert self.file.read()
 
+    def test_read_text_before_first_time_line(self):
+        # Text appearing before the first time line used to crash read() with
+        # an IndexError; such orphan text should just be skipped.
+        path = aeidon.temp.create(self.format.extension)
+        path.write_text(
+            "orphan text\n"
+            "00:00:01,000 --> 00:00:04,000\n"
+            "Hello\n",
+            encoding="ascii")
+        subtitles = aeidon.files.new(self.format, path, "ascii").read()
+        assert len(subtitles) == 1
+        assert subtitles[0].main_text == "Hello"
+
     def test_write(self):
         self.file.write(self.file.read(), aeidon.documents.MAIN)
         text = self.file.path.read_text().strip()


### PR DESCRIPTION
Reading a SubRip file that has any text before the first time line crashes with an `IndexError`:

```python
import aeidon
# a file whose first line is text, not a "HH:MM:SS,mmm --> ..." time line
subtitles = aeidon.files.new(aeidon.formats.SUBRIP, path, "utf_8").read()
# IndexError: list index out of range
```

In `read()`, a line that doesn't match the time-line regex is treated as continuation text and appended to `subtitles[-1]`, but when that line comes before any time line has been seen the list is still empty. A file that opens with a note, or one with no time line at all, hits this. I skip lines that appear before the first time line since they can't belong to any subtitle, added a test, and the file-reader suite still passes.
