### PR TITLE
Raise ParseError on SSA/ASS files missing an [Events] or Format line

### DIFF
--- a/aeidon/files/ssa.py
+++ b/aeidon/files/ssa.py
@@ -101,12 +101,15 @@ class SubStationAlpha(aeidon.SubtitleFile):
         subtitles = []
         lines = self._read_lines()
         self._read_header(lines)
+        fields = None
         for line in lines:
             if not line.startswith("Format:"): continue
             line = line.replace("Format:", "").strip()
             fields = self._re_separator.split(line)
             indices = dict((x, fields.index(x)) for x in fields)
             max_split = len(fields) - 1
+        if fields is None:
+            raise aeidon.ParseError("No 'Format:' line found in the '[Events]' section")
         for line in lines:
             if not line.startswith("Dialogue:"): continue
             line = line.replace("Dialogue:", "").lstrip()
@@ -121,7 +124,7 @@ class SubStationAlpha(aeidon.SubtitleFile):
     def _read_header(self, lines):
         """Read header and remove its lines."""
         self.header = ""
-        while not lines[0].startswith("[Events]"):
+        while lines and not lines[0].startswith("[Events]"):
             self.header += "\n"
             self.header += lines.pop(0)
         self.header = self.header.strip()

--- a/aeidon/files/test/test_ssa.py
+++ b/aeidon/files/test/test_ssa.py
@@ -30,6 +30,18 @@ class TestSubStationAlpha(aeidon.TestCase):
         assert self.file.read()
         assert self.file.header
 
+    def test_read_without_format_line(self):
+        # A file without a "Format:" line, an "[Events]" section, or any
+        # content used to crash read() with UnboundLocalError or IndexError.
+        for text in ("",
+                     "[Script Info]\nScriptType: v4.00\n",
+                     "[Script Info]\n\n[Events]\n"
+                     "Dialogue: Marked=0,0:00:01.00,0:00:04.00,Def,,0,0,0,,x\n"):
+            path = aeidon.temp.create(self.format.extension)
+            path.write_text(text, encoding="ascii")
+            file = aeidon.files.new(self.format, path, "ascii")
+            self.assert_raises(aeidon.ParseError, file.read)
+
     def test_write(self):
         self.file.write(self.file.read(), aeidon.documents.MAIN)
         text = self.file.path.read_text().strip()


### PR DESCRIPTION
The SSA reader (which ASS inherits) assumes a well-formed file and crashes on a few malformed ones. A file with an `[Events]` section but no `Format:` line raises `UnboundLocalError` (`max_split` and `fields` are only set inside the loop that scans for `Format:`), and a file with no `[Events]` section at all makes `_read_header` pop every line and then index the empty list, raising `IndexError`. Empty and header-only files hit these too.

```python
import aeidon
# an .ssa/.ass file that has no "Format:" line
aeidon.files.new(aeidon.formats.SSA, path, "utf_8").read()
# UnboundLocalError: cannot access local variable 'max_split' ...
```

I initialize `fields` and raise `aeidon.ParseError` when there's no `Format:` line, and stop the header loop once the lines run out, so these surface as `ParseError` the way the reader intends rather than a raw exception. Added a test covering the no-format, no-events, empty, and header-only cases; the file-reader suite passes.
